### PR TITLE
KG-14460: Implementing secure long-polling

### DIFF
--- a/src/main/java/org/kaazing/gateway/transport/wseb/WsebConnectProcessor.java
+++ b/src/main/java/org/kaazing/gateway/transport/wseb/WsebConnectProcessor.java
@@ -255,7 +255,7 @@ public class WsebConnectProcessor extends BridgeConnectProcessor<WsebSession> {
         while (true);
     }
 
-    private void finishWrite(final WsebSession session, final BridgeSession writer) {
+    private void finishWrite(final WsebSession session, final HttpSession writer) {
         // ensure upstream is serialized to avoid out-of-order delivery
         session.suspendWrite();
 

--- a/src/main/java/org/kaazing/gateway/transport/wseb/WsebDownstreamHandler.java
+++ b/src/main/java/org/kaazing/gateway/transport/wseb/WsebDownstreamHandler.java
@@ -203,8 +203,6 @@ public class WsebDownstreamHandler extends IoHandlerAdapter<HttpAcceptSession> {
         final ActiveWsExtensions extensions = ActiveWsExtensions.get(wsebSession);
 
         codec.setExtensions(session, extensions);
-
-        bridgeFilterChain.addLast(RECONNECT_FILTER, new WsebReconnectFilter(wsebSession));
     }
 
     public void removeBridgeFilters(IoFilterChain filterChain) {
@@ -265,8 +263,11 @@ public class WsebDownstreamHandler extends IoHandlerAdapter<HttpAcceptSession> {
             longPoll = true;
         }
 
-        // disable pipelining, avoid the need for HTTP chunking
-        session.setWriteHeader("Connection", "close");
+        if (!longPoll) {
+            // In long-polling, Content-Length would be sent. So, don't send Connection:close
+            // disable pipelining, avoid the need for HTTP chunking
+            session.setWriteHeader("Connection", "close");
+        }
 
         // set the content type header
         String contentType = this.contentType;

--- a/src/test/java/org/kaazing/gateway/transport/wseb/WsebProxyTestIT.java
+++ b/src/test/java/org/kaazing/gateway/transport/wseb/WsebProxyTestIT.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -44,14 +44,12 @@ public class WsebProxyTestIT {
     private RobotRule robot = new RobotRule();
     KeyStore keyStore = null;
     char[] password = "ab987c".toCharArray();
-    File keyStorePwFile = new File("src/test/resources/gateway/conf/keystore.pw");
 
     private GatewayRule gateway = new GatewayRule() {
         {
             try {
                 keyStore = KeyStore.getInstance("JCEKS");              
-                FileInputStream in = new FileInputStream(
-                        "src/test/resources/gateway/conf/keystore.db");
+                FileInputStream in = new FileInputStream("target/truststore/keystore.db");
                 keyStore.load(in, password);
             } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -62,25 +60,26 @@ public class WsebProxyTestIT {
                         .property(Gateway.GATEWAY_CONFIG_DIRECTORY_PROPERTY,
                                   "src/test/resources/gateway/conf")
                         .service()
-                            .accept(URI.create("ws://localhost:8001/echo"))
-                             .accept(URI.create("wss://localhost:9002/echo"))
-                            .accept(URI.create("wss://localhost:9001/echo"))
+                            .accept(URI.create("wse://localhost:8001/echo"))
+                             .accept(URI.create("wse+ssl://localhost:9002/echo"))
+                            .accept(URI.create("wse+ssl://localhost:9001/echo"))
 
                             .type("echo")
                             .crossOrigin()
                                 .allowOrigin("*")
                             .done()
                         .done()
-                        .security()      
-                    // TODO: keyStoreFile and keyStorePasswordFile are
-                    // deprecated method which will be removed eventually(4.0.1
-                    // time frame) and keyStore + keyStorePassword should be
-                    // sufficient.
-                    // KG-8840
-                        .keyStoreFile("src/test/resources/gateway/conf/keystore.db")
+                        .service()
+                            .accept(URI.create("wse+ssl://localhost:9003/echo"))
+                            .type("echo")
+                            .crossOrigin()
+                                .allowOrigin("*")
+                            .done()
+                            .acceptOption("ssl.encryption", "disabled")
+                        .done()
+                    .security()
                         .keyStore(keyStore)
                         .keyStorePassword(password)
-                        .keyStorePasswordFile(keyStorePwFile)
                         .done()
                     .done();
             // @formatter:on
@@ -105,7 +104,23 @@ public class WsebProxyTestIT {
     public void BluecoatHeaderDetectionAndFallbackToProxyMode() throws Exception {
         robot.join();
     }
-   
-    
-    
+
+    @Robotic("wsebLongPolling")
+    @Test(timeout = 7500)
+    public void wsebLongPolling() throws Exception {
+        robot.join();
+    }
+
+    @Robotic("wsebSecureLongPolling")
+    @Test(timeout = 7500)
+    public void wsebSecureLongPolling() throws Exception {
+        robot.join();
+    }
+
+    @Robotic("wsebLongPollingByHeader")
+    @Test(timeout = 7500)
+    public void wsebLongPollingTriggeredByHeader() throws Exception {
+        robot.join();
+    }
+       
 }

--- a/src/test/scripts/org/kaazing/gateway/transport/wseb/wsebLongPolling.rpt
+++ b/src/test/scripts/org/kaazing/gateway/transport/wseb/wsebLongPolling.rpt
@@ -1,0 +1,211 @@
+#
+# Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Long Polling test - Note that gateway sends Content-Length on the downstream responses
+
+connect tcp://localhost:8001
+connected
+
+write "GET /echo/;e/ct?.ki=p HTTP/1.1\r\n"
+write "Host: localhost:8001\r\n"
+write "Connection: keep-alive\r\n"
+write "X-Origin: http://localhost:8001\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36\r\n"
+write "Accept: */*\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Accept-Encoding: gzip,deflate,sdch\r\n"
+write "Accept-Language: en-US,en;q=0.8\r\n"
+write "\r\n"
+
+
+read "HTTP/1.1 200 OK\r\n"
+read /Content-Length: .*/ "\r\n"
+read /Content-Type: .*/ "\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 201 Created\r\n"
+read /Content-Type: .*/ "\r\n"
+read "\r\n"
+
+#http://localhost:8001/echo/;e/ut/BXfkXWR20OzrDhTUyZvHrnopbk8jqEiR?.ki=p
+#http://localhost:8001/echo/;e/dt/BXfkXWR20OzrDhTUyZvHrnopbk8jqEiR?.ki=p
+
+read "http://localhost:8001/echo/;e/ut/"
+read [(:sessionId){32}]
+read "?.ki=p"
+read "\n"
+read "http://localhost:8001/echo/;e/dt/"
+read [(:sessionId){32}]
+read "?.ki=p"
+read "\n"
+
+read notify UPSTREAM
+
+# ========= Downstream 1 in the same connection ==========
+
+write "GET /echo/;e/dt/"
+write ${sessionId}
+write "?.ki=p HTTP/1.1\r\n"
+write "Host: localhost:8001\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36\r\n"
+write "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n"
+write "Accept-Language: en-US,en;q=0.5\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "X-Origin: http://localhost:8001\r\n"
+write "Content-Type: application/octet-stream\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Connection: keep-alive\r\n"
+write "\r\n"
+
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: no-cache\r\n"
+read /Content-Length: .*/ "\r\n"
+read /Content-Type: .*/ "\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "X-Content-Type-Options: nosniff\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read /Content-Type: .*/ "\r\n"
+read "X-Idle-Timeout: 60\r\n"
+read "\r\n"
+read [0x80 0x11]
+read "Hello, WebSocket1"
+read [0x01 0x30 0x31 0xff]
+
+read notify UPSTREAMNEXT
+
+# ========= Downstream 2 in the same connection ==========
+
+write "GET /echo/;e/dt/"
+write ${sessionId}
+write "?.ki=p HTTP/1.1\r\n"
+write "Host: localhost:8001\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36\r\n"
+write "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n"
+write "Accept-Language: en-US,en;q=0.5\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "X-Origin: http://localhost:8001\r\n"
+write "Content-Type: application/octet-stream\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Connection: keep-alive\r\n"
+write "\r\n"
+
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: no-cache\r\n"
+read /Content-Length: .*/ "\r\n"
+read /Content-Type: .*/ "\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "X-Content-Type-Options: nosniff\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read /Content-Type: .*/ "\r\n"
+read "X-Idle-Timeout: 60\r\n"
+read "\r\n"
+read [0x80 0x11]
+read "Hello, WebSocket2"
+read [0x01 0x30 0x31 0xff]
+
+close
+closed
+
+
+
+# ======= upstream 1 =======
+
+
+connect tcp://localhost:8001
+connected
+
+write await UPSTREAM
+
+write "POST /echo/;e/ut/"
+write ${sessionId}
+write "?.ki=p HTTP/1.1\r\n"
+write "Host: localhost:8001\r\n"
+write "Connection: keep-alive\r\n"
+write "Content-Length: 25\r\n"
+write "Origin: http://localhost:8001\r\n"
+write "X-Origin: http://localhost:8001\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36\r\n"
+write "Content-Type: text/plain; charset=UTF-8\r\n"
+write "Accept: */*\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "Accept-Language: en-US,en;q=0.8\r\n"
+write "\r\n"
+write [0xc2 0x81 0x11]
+write "Hello, WebSocket1"
+write [0x01 0x30 0x31 0xc3 0xbf]    # wse.reconnect
+
+read "HTTP/1.1 200 OK\r\n"
+read /Content-Length: .*/ "\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "\r\n"
+
+close
+closed
+
+
+# ======= upstream 2 ===========
+
+connect tcp://localhost:8001
+connected
+
+write await UPSTREAMNEXT
+
+write "POST /echo/;e/ut/"
+write ${sessionId}
+write "?.ki=p HTTP/1.1\r\n"
+write "Host: localhost:8001\r\n"
+write "Connection: keep-alive\r\n"
+write "Content-Length: 25\r\n"
+write "Origin: http://localhost:8001\r\n"
+write "X-Origin: http://localhost:8001\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36\r\n"
+write "Content-Type: text/plain; charset=UTF-8\r\n"
+write "Accept: */*\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "Accept-Language: en-US,en;q=0.8\r\n"
+write "\r\n"
+write [0xc2 0x81 0x11]
+write "Hello, WebSocket2"
+write [0x01 0x30 0x31 0xc3 0xbf]    # wse.reconnect
+
+read "HTTP/1.1 200 OK\r\n"
+read /Content-Length: .*/ "\r\n"
+read /Content-Type: .*/ "\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "\r\n"
+
+close
+closed

--- a/src/test/scripts/org/kaazing/gateway/transport/wseb/wsebLongPollingByHeader.rpt
+++ b/src/test/scripts/org/kaazing/gateway/transport/wseb/wsebLongPollingByHeader.rpt
@@ -1,0 +1,215 @@
+#
+# Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Long Polling test - Note that gateway sends Content-Length on the downstream responses
+# Long Polling is triggered by intermediary (like proxy) with "X-Kaazing-Proxy-Buffering: on" header
+
+connect tcp://localhost:8001
+connected
+
+write "GET /echo/;e/ct HTTP/1.1\r\n"
+write "Host: localhost:8001\r\n"
+write "Connection: keep-alive\r\n"
+write "X-Kaazing-Proxy-Buffering: on\r\n"
+write "X-Origin: http://localhost:8001\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36\r\n"
+write "Accept: */*\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Accept-Encoding: gzip,deflate,sdch\r\n"
+write "Accept-Language: en-US,en;q=0.8\r\n"
+write "\r\n"
+
+
+read "HTTP/1.1 200 OK\r\n"
+read /Content-Length: .*/ "\r\n"
+read /Content-Type: .*/ "\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 201 Created\r\n"
+read /Content-Type: .*/ "\r\n"
+read "\r\n"
+
+#http://localhost:8001/echo/;e/ut/BXfkXWR20OzrDhTUyZvHrnopbk8jqEiR
+#http://localhost:8001/echo/;e/dt/BXfkXWR20OzrDhTUyZvHrnopbk8jqEiR
+
+read "http://localhost:8001/echo/;e/ut/"
+read [(:sessionId){32}]
+read "\n"
+read "http://localhost:8001/echo/;e/dt/"
+read [(:sessionId){32}]
+read "\n"
+
+read notify UPSTREAM
+
+# ========= Downstream 1 in the same connection ==========
+
+write "GET /echo/;e/dt/"
+write ${sessionId}
+write " HTTP/1.1\r\n"
+write "X-Kaazing-Proxy-Buffering: on\r\n"
+write "Host: localhost:8001\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36\r\n"
+write "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n"
+write "Accept-Language: en-US,en;q=0.5\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "X-Origin: http://localhost:8001\r\n"
+write "Content-Type: application/octet-stream\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Connection: keep-alive\r\n"
+write "\r\n"
+
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: no-cache\r\n"
+read /Content-Length: .*/ "\r\n"
+read /Content-Type: .*/ "\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "X-Content-Type-Options: nosniff\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read /Content-Type: .*/ "\r\n"
+read "X-Idle-Timeout: 60\r\n"
+read "\r\n"
+read [0x80 0x11]
+read "Hello, WebSocket1"
+read [0x01 0x30 0x31 0xff]
+
+read notify UPSTREAMNEXT
+
+# ========= Downstream 2 in the same connection ==========
+
+write "GET /echo/;e/dt/"
+write ${sessionId}
+write " HTTP/1.1\r\n"
+write "X-Kaazing-Proxy-Buffering: on\r\n"
+write "Host: localhost:8001\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36\r\n"
+write "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n"
+write "Accept-Language: en-US,en;q=0.5\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "X-Origin: http://localhost:8001\r\n"
+write "Content-Type: application/octet-stream\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Connection: keep-alive\r\n"
+write "\r\n"
+
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: no-cache\r\n"
+read /Content-Length: .*/ "\r\n"
+read /Content-Type: .*/ "\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "X-Content-Type-Options: nosniff\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read /Content-Type: .*/ "\r\n"
+read "X-Idle-Timeout: 60\r\n"
+read "\r\n"
+read [0x80 0x11]
+read "Hello, WebSocket2"
+read [0x01 0x30 0x31 0xff]
+
+close
+closed
+
+
+
+# ======= upstream 1 =======
+
+
+connect tcp://localhost:8001
+connected
+
+write await UPSTREAM
+
+write "POST /echo/;e/ut/"
+write ${sessionId}
+write " HTTP/1.1\r\n"
+write "X-Kaazing-Proxy-Buffering: on\r\n"
+write "Host: localhost:8001\r\n"
+write "Connection: keep-alive\r\n"
+write "Content-Length: 25\r\n"
+write "Origin: http://localhost:8001\r\n"
+write "X-Origin: http://localhost:8001\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36\r\n"
+write "Content-Type: text/plain; charset=UTF-8\r\n"
+write "Accept: */*\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "Accept-Language: en-US,en;q=0.8\r\n"
+write "\r\n"
+write [0xc2 0x81 0x11]
+write "Hello, WebSocket1"
+write [0x01 0x30 0x31 0xc3 0xbf]    # wse.reconnect
+
+read "HTTP/1.1 200 OK\r\n"
+read /Content-Length: .*/ "\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "\r\n"
+
+close
+closed
+
+
+# ======= upstream 2 ===========
+
+connect tcp://localhost:8001
+connected
+
+write await UPSTREAMNEXT
+
+write "POST /echo/;e/ut/"
+write ${sessionId}
+write " HTTP/1.1\r\n"
+write "X-Kaazing-Proxy-Buffering: on\r\n"
+write "Host: localhost:8001\r\n"
+write "Connection: keep-alive\r\n"
+write "Content-Length: 25\r\n"
+write "Origin: http://localhost:8001\r\n"
+write "X-Origin: http://localhost:8001\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36\r\n"
+write "Content-Type: text/plain; charset=UTF-8\r\n"
+write "Accept: */*\r\n"
+write "Referer: http://localhost:8001/?.kr=xs\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "Accept-Language: en-US,en;q=0.8\r\n"
+write "\r\n"
+write [0xc2 0x81 0x11]
+write "Hello, WebSocket2"
+write [0x01 0x30 0x31 0xc3 0xbf]    # wse.reconnect
+
+read "HTTP/1.1 200 OK\r\n"
+read /Content-Length: .*/ "\r\n"
+read /Content-Type: .*/ "\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "\r\n"
+
+close
+closed

--- a/src/test/scripts/org/kaazing/gateway/transport/wseb/wsebSecureLongPolling.rpt
+++ b/src/test/scripts/org/kaazing/gateway/transport/wseb/wsebSecureLongPolling.rpt
@@ -1,0 +1,212 @@
+#
+# Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Secure Long Polling test - Note that gateway sends Content-Length on the downstream responses
+# See the https urls for upstream and downstream
+
+connect tcp://localhost:9003
+connected
+
+write "GET /echo/;e/ct?.ki=p HTTP/1.1\r\n"
+write "Host: localhost:9003\r\n"
+write "Connection: keep-alive\r\n"
+write "X-Origin: http://localhost:9003\r\n"
+write "X-WebSocket-Version: wseb-1.0\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36\r\n"
+write "Accept: */*\r\n"
+write "Referer: http://localhost:9003/?.kr=xs\r\n"
+write "Accept-Encoding: gzip,deflate,sdch\r\n"
+write "Accept-Language: en-US,en;q=0.8\r\n"
+write "\r\n"
+
+
+read "HTTP/1.1 200 OK\r\n"
+read /Content-Length: .*/ "\r\n"
+read /Content-Type: .*/ "\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 201 Created\r\n"
+read /Content-Type: .*/ "\r\n"
+read "\r\n"
+
+#https://localhost:9003/echo/;e/ut/BXfkXWR20OzrDhTUyZvHrnopbk8jqEiR?.ki=p
+#https://localhost:9003/echo/;e/dt/BXfkXWR20OzrDhTUyZvHrnopbk8jqEiR?.ki=p
+
+read "https://localhost:9003/echo/;e/ut/"
+read [(:sessionId){32}]
+read "?.ki=p"
+read "\n"
+read "https://localhost:9003/echo/;e/dt/"
+read [(:sessionId){32}]
+read "?.ki=p"
+read "\n"
+
+read notify UPSTREAM
+
+# ========= Downstream 1 in the same connection ==========
+
+write "GET /echo/;e/dt/"
+write ${sessionId}
+write "?.ki=p HTTP/1.1\r\n"
+write "Host: localhost:9003\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36\r\n"
+write "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n"
+write "Accept-Language: en-US,en;q=0.5\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "X-Origin: http://localhost:9003\r\n"
+write "Content-Type: application/octet-stream\r\n"
+write "Referer: http://localhost:9003/?.kr=xs\r\n"
+write "Connection: keep-alive\r\n"
+write "\r\n"
+
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: no-cache\r\n"
+read /Content-Length: .*/ "\r\n"
+read /Content-Type: .*/ "\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "X-Content-Type-Options: nosniff\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read /Content-Type: .*/ "\r\n"
+read "X-Idle-Timeout: 60\r\n"
+read "\r\n"
+read [0x80 0x11]
+read "Hello, WebSocket1"
+read [0x01 0x30 0x31 0xff]
+
+read notify UPSTREAMNEXT
+
+# ========= Downstream 2 in the same connection ==========
+
+write "GET /echo/;e/dt/"
+write ${sessionId}
+write "?.ki=p HTTP/1.1\r\n"
+write "Host: localhost:9003\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36\r\n"
+write "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n"
+write "Accept-Language: en-US,en;q=0.5\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "X-Origin: http://localhost:9003\r\n"
+write "Content-Type: application/octet-stream\r\n"
+write "Referer: http://localhost:9003/?.kr=xs\r\n"
+write "Connection: keep-alive\r\n"
+write "\r\n"
+
+read "HTTP/1.1 200 OK\r\n"
+read "Cache-Control: no-cache\r\n"
+read /Content-Length: .*/ "\r\n"
+read /Content-Type: .*/ "\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "X-Content-Type-Options: nosniff\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read /Content-Type: .*/ "\r\n"
+read "X-Idle-Timeout: 60\r\n"
+read "\r\n"
+read [0x80 0x11]
+read "Hello, WebSocket2"
+read [0x01 0x30 0x31 0xff]
+
+close
+closed
+
+
+
+# ======= upstream 1 =======
+
+
+connect tcp://localhost:9003
+connected
+
+write await UPSTREAM
+
+write "POST /echo/;e/ut/"
+write ${sessionId}
+write "?.ki=p HTTP/1.1\r\n"
+write "Host: localhost:9003\r\n"
+write "Connection: keep-alive\r\n"
+write "Content-Length: 25\r\n"
+write "Origin: http://localhost:9003\r\n"
+write "X-Origin: http://localhost:9003\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36\r\n"
+write "Content-Type: text/plain; charset=UTF-8\r\n"
+write "Accept: */*\r\n"
+write "Referer: http://localhost:9003/?.kr=xs\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "Accept-Language: en-US,en;q=0.8\r\n"
+write "\r\n"
+write [0xc2 0x81 0x11]
+write "Hello, WebSocket1"
+write [0x01 0x30 0x31 0xc3 0xbf]    # wse.reconnect
+
+read "HTTP/1.1 200 OK\r\n"
+read /Content-Length: .*/ "\r\n"
+read "Content-Type: text/plain;charset=UTF-8\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "\r\n"
+
+close
+closed
+
+
+# ======= upstream 2 ===========
+
+connect tcp://localhost:9003
+connected
+
+write await UPSTREAMNEXT
+
+write "POST /echo/;e/ut/"
+write ${sessionId}
+write "?.ki=p HTTP/1.1\r\n"
+write "Host: localhost:9003\r\n"
+write "Connection: keep-alive\r\n"
+write "Content-Length: 25\r\n"
+write "Origin: http://localhost:9003\r\n"
+write "X-Origin: http://localhost:9003\r\n"
+write "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36\r\n"
+write "Content-Type: text/plain; charset=UTF-8\r\n"
+write "Accept: */*\r\n"
+write "Referer: http://localhost:9003/?.kr=xs\r\n"
+write "Accept-Encoding: gzip, deflate\r\n"
+write "Accept-Language: en-US,en;q=0.8\r\n"
+write "\r\n"
+write [0xc2 0x81 0x11]
+write "Hello, WebSocket2"
+write [0x01 0x30 0x31 0xc3 0xbf]    # wse.reconnect
+
+read "HTTP/1.1 200 OK\r\n"
+read /Content-Length: .*/ "\r\n"
+read /Content-Type: .*/ "\r\n"
+read /Date: .*/ "\r\n"
+read "Server: Kaazing Gateway\r\n"
+read "\r\n"
+read "HTTP/1.1 200 OK\r\n"
+read "\r\n"
+
+close
+closed


### PR DESCRIPTION
* Now gateway adds Content-Length on downstream responses. This helps the client to reuse
an underlying connection for multiple HTTP request/responses. When long polling is detected,
it calls suspendWrite(), write data, shutdownWrite(), resumeWrite() on downstream HTTP connection.
This enables the data to be buffered and Content-Length to be written.

* canStream() logic is changed. Previously, if there certain headers like (Via etc), gateway
doesn't stream at all eventhough a proxy may support streaming. The new logic gives an opportunity
to stream even when proxy is in the path. If the proxy buffers, the client would establish
a connection (after certain duration) with .ki=p and that would trigger long-polling.

* X-Kaazing-Proxy-Buffering: on|off is implemented. buffer size is not implemented. This is
only hint to gateway for the first request but not required as client would send .ki=p on
subsequent requests to trigger long polling.